### PR TITLE
Update 0.6.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -32,3 +32,8 @@ Hotfix for a Typo, allowing 57 Modules in an Assembler instead of the desired 7
 New Icon Art
 Nerfed Crafting Speed of normal Assemblers to a maximum of 5.00
 Updated Dependencies to their newest versions
+
+-0.6.1 - 14th December 2019
+Fixed Pollution of electronic Assemblers, T4 generating 0.1 less thant T3 and T5 generating 0.1 less than T4
+Adjusted Module Slots to 7 and 8 for electronic assembler T4 and T5 (Down from 8 and 10)
+Adjusted energy usage of electronic assembler T4 and T5 to 800kW and 1000kW to be more in line with the other machines

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "MilesBobsExpansion",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "factorio_version": "0.17",
   "title": "Miles' Bob's Expansion",
   "author": "TehFocus",

--- a/prototypes/assembly-electronics.lua
+++ b/prototypes/assembly-electronics.lua
@@ -128,13 +128,13 @@ data:extend(
     {
       type = "electric",
       usage_priority = "secondary-input",
-      emissions = 0.012
+      emissions = 0.0005
     },
-    energy_usage = "500kW",
+    energy_usage = "800kW",
     ingredient_count = 6,
     module_specification =
     {
-      module_slots = 8,
+      module_slots = 7,
     },
     allowed_effects = {"consumption", "speed", "productivity", "pollution"}
   },
@@ -240,9 +240,10 @@ data:extend(
 		new_assembler.crafting_speed="8.0"
 		new_assembler.order="d[electronics-machine-5]"
 		new_assembler.animation.layers[2].tint={r = 1.0, g = 1.0, b = 1.0}
-		new_assembler.energy_usage="800kW"
+		new_assembler.energy_usage="1000kW"
+		new_assembler.energy_source={type = "electric", usage_priority = "secondary-input", emissions = 0.0003}
 		new_assembler.minable={hardness = 0.2, mining_time = 0.5, result = "electronics-machine-5"}
-		new_assembler.module_specification.module_slots="10"
+		new_assembler.module_specification.module_slots="8"
 		data:extend{new_assembler}
 		
 		local new_assembleritem=table.deepcopy(data.raw["item"]["electronics-machine-4"])


### PR DESCRIPTION
Fixed Pollution of electronic Assemblers, T4 generating 0.1 less thant T3 and T5 generating 0.1 less than T4
Adjusted Module Slots to 7 and 8 for electronic assembler T4 and T5 (Down from 8 and 10)
Adjusted energy usage of electronic assembler T4 and T5 to 800kW and 1000kW to be more in line with the other machines