### PR TITLE
Hotfix Update 0.8.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -45,3 +45,7 @@ Updated for 0.18, again: Was being lazy, literally just had to change version nu
 Happy Birthday to me! Spent the night adding conditional recipes. Depending if bobplates and/or bobelectronics are present, recipes change
 Adjusted crafting speed and module slots
 Fixed technology icon as well as some machine icons
+
+-0.8.1 - 20th July 2020
+Hotfix for crafting speed of assemblers. T7 now actually better than T6. Raised maximum craft speed of all machines
+Adjusted conditional recipes for Bob's Plates and/or Bobs'Electronics to be more in-line with high tier metals. Additional CPU requirement removed.

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "MilesBobsExpansion",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "factorio_version": "0.18",
   "title": "Miles' Bob's Expansion",
   "author": "TehFocus",

--- a/prototypes/assembly-electronics.lua
+++ b/prototypes/assembly-electronics.lua
@@ -271,8 +271,9 @@ data:extend(
 				{
 					{"electronics-machine-3", 1},
 					{"processing-unit", 10},
+					{"nitinol-alloy", 10},
+					{"nitinol-bearing", 10},
 					{"tungsten-carbide", 10},
-					{"tungsten-gear-wheel", 10},
 					{"speed-module-5", 5},
 				}
 		end
@@ -293,8 +294,9 @@ data:extend(
 				{
 					{"electronics-machine-3", 1},
 					{"advanced-processing-unit", 10},
+					{"nitinol-alloy", 10},
+					{"nitinol-bearing", 10},
 					{"tungsten-carbide", 10},
-					{"tungsten-gear-wheel", 10},
 					{"speed-module-5", 5},
 				}
 		end
@@ -319,7 +321,7 @@ data:extend(
 				{
 					{"electronics-machine-4", 1},
 					{"processing-unit", 20},
-					{"cobalt-steel-alloy", 20},
+					{"copper-tungsten-alloy", 20},
 					{"nitinol-bearing", 20},
 					{"speed-module-6", 5},
 				}
@@ -341,7 +343,7 @@ data:extend(
 				{
 					{"electronics-machine-4", 1},
 					{"advanced-processing-unit", 20},
-					{"cobalt-steel-alloy", 20},
+					{"copper-tungsten-alloy", 20},
 					{"nitinol-bearing", 20},
 					{"speed-module-6", 5},
 				}

--- a/prototypes/assembly.lua
+++ b/prototypes/assembly.lua
@@ -128,7 +128,7 @@ data:extend(
       apparent_volume = 1.5,
     },
     crafting_categories = {"crafting", "advanced-crafting", "crafting-with-fluid"},
-    crafting_speed = 3,
+    crafting_speed = 4,
     energy_source =
     {
       type = "electric",
@@ -325,7 +325,7 @@ data:extend(
 		local new_assembler=table.deepcopy(data.raw["assembling-machine"]["assembling-machine-7"])
 		new_assembler.name="assembling-machine-8"
 		new_assembler.icon="__MilesBobsExpansion__/graphics/icons/assembling-machine-8.png"
-		new_assembler.crafting_speed="4.0"
+		new_assembler.crafting_speed="5.0"
 		new_assembler.order="c[assembling-machine-8]"
 		new_assembler.animation.layers[2].tint ={r = 243/255, g = 136/255, b = 213/255}
 		new_assembler.energy_usage="1000kW"
@@ -343,7 +343,7 @@ data:extend(
 		local new_assembler=table.deepcopy(data.raw["assembling-machine"]["assembling-machine-7"])
 		new_assembler.name="assembling-machine-9"
 		new_assembler.icon="__MilesBobsExpansion__/graphics/icons/assembling-machine-9.png"
-		new_assembler.crafting_speed="4.50"
+		new_assembler.crafting_speed="5.50"
 		new_assembler.order="c[assembling-machine-9]"
 		new_assembler.animation.layers[2].tint={r = 0.9, g = 0.7, b = 0.0}
 		new_assembler.energy_usage="1250kW"
@@ -361,7 +361,7 @@ data:extend(
 		local new_assembler=table.deepcopy(data.raw["assembling-machine"]["assembling-machine-7"])
 		new_assembler.name="assembling-machine-10"
 		new_assembler.icon="__MilesBobsExpansion__/graphics/icons/assembling-machine-10.png"
-		new_assembler.crafting_speed="5.00"
+		new_assembler.crafting_speed="6.00"
 		new_assembler.order="c[x-assembling-machine-9+1]"
 		new_assembler.animation.layers[2].tint={r = 1.0, g = 1.0, b = 1.0}
 		new_assembler.energy_usage="2000kW"
@@ -559,7 +559,6 @@ data:extend(
 				{
 					{"assembling-machine-9", 1},
 					{"advanced-processing-unit", 20},
-					{"processing-electronics", 20},
 					{"steel-plate", 30},
 					{"iron-plate", 30},
 					{"iron-gear-wheel", 30},
@@ -572,7 +571,6 @@ data:extend(
 				{
 					{"assembling-machine-9", 1},
 					{"advanced-processing-unit", 20},
-					{"processing-electronics", 20},
 					{"cobalt-steel-alloy", 20},
 					{"nitinol-alloy", 20},
 					{"nitinol-bearing", 20},


### PR DESCRIPTION
-0.8.1 - 20th July 2020
Hotfix for crafting speed of assemblers. T7 now actually better than T6. Raised maximum craft speed of all machines
Adjusted conditional recipes for Bob's Plates and/or Bobs'Electronics to be more in-line with high tier metals. Additional CPU requirement removed.